### PR TITLE
docs: Sync version references to v3.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Debian (Zorin OS, Ubuntu) ve RHEL (Fedora) tabanlı sistemlerde; Snapshot (Yedek
     * Sistem paketleri, Flatpak, Snap ve `fwupdmgr` (Firmware) güncellemeleri.
 * **Ironclad Güvenlik:**
     * "Strict Mode" (`set -Eeuo pipefail`) ile hata toleransı sıfır.
-* **Bilgilendirici Özet (v3.4.4):**
+* **Bilgilendirici Özet (v3.4.6):**
     * Başlangıçta sistem bilgileri (host, kernel, RAM, disk).
     * Sonunda detaylı özet (kaç paket güncellendi, reboot gerekli mi).
 * **Akıllı Installer:**
@@ -74,7 +74,7 @@ Performs Snapshot (Backup), Repository Updates, Flatpak/Snap and Firmware checks
     * System packages, Flatpak, Snap and `fwupdmgr` (Firmware) updates.
 * **Ironclad Security:**
     * Zero error tolerance with "Strict Mode" (`set -Eeuo pipefail`).
-* **Informative Summary (v3.4.4):**
+* **Informative Summary (v3.4.6):**
     * System info at start (host, kernel, RAM, disk).
     * Detailed summary at end (packages updated, reboot required).
 * **Smart Installer:**

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ARCB Updater Installer v3.4.2 (Solid Foundation)
-# Sync: v3.4.2 | Feature: Smart Local File Detection (Script Dir > CWD > Web)
+# ARCB Updater Installer v3.4.6 (Solid Foundation)
+# Sync: v3.4.6 | Feature: Smart Local File Detection (Script Dir > CWD > Web)
 
 # 1. HATA YÖNETİMİ
 set -Eeuo pipefail
@@ -81,7 +81,7 @@ download_file() {
     fi
 }
 
-echo -e "\n${BLUE}>>> ARCB Wider Updater Kurulum (v3.4.2)${NC}"
+echo -e "\n${BLUE}>>> ARCB Wider Updater Kurulum (v3.4.6)${NC}"
 
 # İndirme veya Kopyalama Mantığı
 if [[ -n "$SOURCE_FILE" ]]; then


### PR DESCRIPTION
## Summary
Synchronize version references across documentation files for v3.4.6 release.

## Changes
- **README.md**: Updated v3.4.4 → v3.4.6 (Bilgilendirici Özet references)
- **install.sh**: Updated v3.4.2 → v3.4.6 (header comments and echo messages)

## Verified Files (No changes needed)
- ✅ CHANGELOG.md - All versions (v3.4.3, v3.4.4, v3.4.5, v3.4.6) present
- ✅ guncel - VERSION="3.4.6" correct
- ✅ CONTRIBUTING.md - Up to date
- ✅ SECURITY.md - Up to date