### PR TITLE
v3.5.0: Add flock concurrent execution lock and DNF lock retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v3.5.0] - 2026-01-25
+
+### Added
+- Concurrent execution lock using `flock` (prevents cron + manual conflicts)
+- DNF lock retry mechanism with `wait_for_dnf_lock()` function
+  - Uses `pgrep` to check for running dnf/yum/rpm processes
+  - Max 30 attempts with 10 second intervals
+  - Gracefully skips DNF update if lock cannot be acquired
+
+### Changed
+- CODENAME: "Colorful" → "Locked & Loaded"
+
+### Notes
+- `flock` is typically included with `util-linux` package (pre-installed on most systems)
+
 ## [v3.4.6] - 2026-01-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Debian (Zorin OS, Ubuntu) ve RHEL (Fedora) tabanlı sistemlerde; Snapshot (Yedek
     * Sistem paketleri, Flatpak, Snap ve `fwupdmgr` (Firmware) güncellemeleri.
 * **Ironclad Güvenlik:**
     * "Strict Mode" (`set -Eeuo pipefail`) ile hata toleransı sıfır.
-* **Bilgilendirici Özet (v3.4.6):**
+* **Bilgilendirici Özet (v3.5.0):**
+* **Eşzamanlı Çalışma Kilidi (v3.5.0):**
+    * `flock` ile cron ve manuel çalıştırma çakışmasını önler.
+* **DNF Kilit Bekleme (v3.5.0):**
+    * DNF/YUM/RPM işlemleri için akıllı bekleme mekanizması.
     * Başlangıçta sistem bilgileri (host, kernel, RAM, disk).
     * Sonunda detaylı özet (kaç paket güncellendi, reboot gerekli mi).
 * **Akıllı Installer:**
@@ -74,7 +78,11 @@ Performs Snapshot (Backup), Repository Updates, Flatpak/Snap and Firmware checks
     * System packages, Flatpak, Snap and `fwupdmgr` (Firmware) updates.
 * **Ironclad Security:**
     * Zero error tolerance with "Strict Mode" (`set -Eeuo pipefail`).
-* **Informative Summary (v3.4.6):**
+* **Informative Summary (v3.5.0):**
+* **Concurrent Execution Lock (v3.5.0):**
+    * Prevents cron and manual execution conflicts using `flock`.
+* **DNF Lock Retry (v3.5.0):**
+    * Smart waiting mechanism for DNF/YUM/RPM operations.
     * System info at start (host, kernel, RAM, disk).
     * Detailed summary at end (packages updated, reboot required).
 * **Smart Installer:**

--- a/guncel
+++ b/guncel
@@ -5,8 +5,8 @@
 #
 
 # --- AYARLAR ---
-VERSION="3.4.6"
-CODENAME="Colorful"
+VERSION="3.5.0"
+CODENAME="Locked & Loaded"
 LOG_DIR="/var/log/arcb-updater"
 LOG_FILE="$LOG_DIR/update_$(date +%Y%m%d_%H%M%S).log"
 GITHUB_RAW_URL="https://raw.githubusercontent.com/ahm3t0t/arcb-wider-updater/main/guncel"
@@ -404,6 +404,21 @@ wait_for_lock() {
     done
 }
 
+wait_for_dnf_lock() {
+    local max_attempts=30
+    local attempt=0
+    while [ $attempt -lt $max_attempts ]; do
+        if ! pgrep -x "dnf|yum|rpm" > /dev/null 2>&1; then
+            return 0
+        fi
+        print_warning "DNF kilidi bekleniyor... ($((attempt+1))/$max_attempts)"
+        sleep 10
+        ((attempt++))
+    done
+    print_error "DNF kilidi zaman aşımı!"
+    return 1
+}
+
 create_snapshot() {
     if command -v timeshift &> /dev/null; then
         print_header "Sistem Yedekleniyor (Timeshift)"
@@ -475,6 +490,11 @@ perform_updates() {
         print_info "APT: $APT_COUNT paket güncellendi."
 
     elif command -v dnf &> /dev/null; then
+        # DNF kilidi kontrolü
+        if ! wait_for_dnf_lock; then
+            print_error "DNF kilidi alınamadı, DNF güncellemesi atlanıyor."
+            return
+        fi
         print_header "DNF: Güncelleme"
         
         # Güncelleme sayısını al - FIX: Ensure numeric result
@@ -590,6 +610,14 @@ if [[ "$VERBOSE_MODE" == "true" && "$QUIET_MODE" == "true" ]]; then
 fi
 
 check_root "$@"
+
+# --- FLOCK: Eşzamanlı çalışma kilidi ---
+LOCK_FILE="/var/lock/arcb-wider-updater.lock"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    print_error "Başka bir güncelleme işlemi zaten çalışıyor."
+    exit 1
+fi
 setup_logging
 
 if ! check_connectivity; then

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ARCB Updater Installer v3.4.6 (Solid Foundation)
-# Sync: v3.4.6 | Feature: Smart Local File Detection (Script Dir > CWD > Web)
+# ARCB Updater Installer v3.5.0 (Solid Foundation)
+# Sync: v3.5.0 | Feature: Smart Local File Detection (Script Dir > CWD > Web)
 
 # 1. HATA YÖNETİMİ
 set -Eeuo pipefail
@@ -81,7 +81,7 @@ download_file() {
     fi
 }
 
-echo -e "\n${BLUE}>>> ARCB Wider Updater Kurulum (v3.4.6)${NC}"
+echo -e "\n${BLUE}>>> ARCB Wider Updater Kurulum (v3.5.0)${NC}"
 
 # İndirme veya Kopyalama Mantığı
 if [[ -n "$SOURCE_FILE" ]]; then
@@ -119,6 +119,7 @@ fi
 if install -m 0755 -o root -g root "$TEMP_FILE" "$INSTALL_PATH"; then
     INSTALLED_VERSION=$(sed -n 's/^VERSION="\([^"]*\)".*/\1/p' "$INSTALL_PATH" | head -n1)
     echo -e "${GREEN}✅ Kurulum Başarılı! (v${INSTALLED_VERSION:-Bilinmiyor})${NC}"
+    echo -e "${BLUE}ℹ️  Not: flock bağımlılığı util-linux paketi ile gelir (genelde kurulu).${NC}"
     echo "--------------------------------------------------"
     echo -e "Komut: ${BOLD}guncel${NC} [--auto] [--help]"
 else


### PR DESCRIPTION
## Summary
v3.5.0 "Locked & Loaded" release with concurrent execution protection and DNF lock handling.

## Added
- **Concurrent execution lock using `flock`** - Prevents cron + manual conflicts
  - Uses `/var/lock/arcb-wider-updater.lock`
  - Exits gracefully if another instance is running
  
- **DNF lock retry mechanism** - `wait_for_dnf_lock()` function
  - Uses `pgrep` to check for running dnf/yum/rpm processes
  - Max 30 attempts with 10 second intervals
  - Gracefully skips DNF update if lock cannot be acquired

## Changed
- VERSION: `3.4.6` → `3.5.0`
- CODENAME: `"Colorful"` → `"Locked & Loaded"`

## Files Modified
- `guncel` - Main script with new features
- `install.sh` - Version sync + flock dependency note
- `README.md` - New features documentation
- `CHANGELOG.md` - v3.5.0 entry

## Testing
- ✅ ShellCheck passed
- ✅ Bash syntax check passed

## Notes
- `flock` is typically included with `util-linux` package (pre-installed on most systems)